### PR TITLE
build: bump alloy-transport-ws from 1.0.23 to 1.6.1 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a24c81a56d684f525cd1c012619815ad3a1dd13b0238f069356795d84647d3c"
+checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eb9c9371738ac47f589e40aae6e418cb5f7436ad25b87575a7f94a60ccf43b"
+checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b321f506bd67a434aae8e8a7dfe5373bf66137c149a5f09c9e7dfb0ca43d7c91"
+checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -669,15 +669,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.23"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dbaa6851875d59c8803088f4b6ec72eaeddf7667547ae8995c1a19fbca6303"
+checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.3.1",
- "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,19 +5746,20 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
 dependencies = [
  "assert-json-diff",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
  "log",
+ "pin-project-lite",
  "rand 0.9.1",
  "regex",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ alloy-signer-trezor = { version = "1.0.22", default-features = false }
 alloy-transport = { version = "1.0.22", default-features = false }
 alloy-transport-http = { version = "1.0.22", default-features = false }
 alloy-transport-ipc = { version = "1.1.0", default-features = false }
-alloy-transport-ws = { version = "1.0.22", default-features = false }
+alloy-transport-ws = { version = "1.6.1", default-features = false }
 
 alloy-dyn-abi = { version = "1.2.1", features = ["eip712"] }
 alloy-json-abi = "1.2.1"

--- a/crates/edr_rpc_eth/Cargo.toml
+++ b/crates/edr_rpc_eth/Cargo.toml
@@ -25,7 +25,7 @@ assert-json-diff = "2.0.2"
 edr_chain_l1.workspace = true
 edr_test_utils.workspace = true
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-mockito = { version = "1.0.2", default-features = false }
+mockito = { version = "1.7.2", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 serde_json.workspace = true


### PR DESCRIPTION
## Summary by Sourcery

Update dependency versions for WebSocket transport and test mocking library.

Build:
- Bump alloy-transport-ws dependency from 1.0.22 to 1.6.1 in the main Cargo manifest.
- Upgrade mockito dev-dependency in edr_rpc_eth crate from 1.0.2 to 1.7.2.